### PR TITLE
Copy the cloud directory

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,7 @@ RUN go mod download
 COPY main.go main.go
 COPY api/ api/
 COPY controllers/ controllers/
+COPY cloud/ cloud/
 
 # Build
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -a -o manager main.go


### PR DESCRIPTION
Fixes: #4 

With the change, able to build the docker image:

```
Step 14/16 : COPY --from=builder /workspace/manager .
Copy the cloud directory
 ---> Using cache
 ---> a902e337c53d
Step 15/16 : USER nonroot:nonroot
 ---> Using cache
 ---> 4c66e5103261
Step 16/16 : ENTRYPOINT ["/manager"]
 ---> Using cache
 ---> d85275419556
Successfully built d85275419556
Successfully tagged controller:latest
```